### PR TITLE
feat: add detail to permission error

### DIFF
--- a/stores/firestore/entityMetadata.ts
+++ b/stores/firestore/entityMetadata.ts
@@ -72,6 +72,13 @@ export class EntityMetaData extends EventEmitter {
 
                 if (data === undefined) return;
                 this.emit("parse", data);
+            },
+            (err) => {
+                if (err instanceof Error && err.code === "permission-denied") {
+                    throw new Error(
+                        `You don't have permission to access ${this.reference?.path}`
+                    );
+                }
             }
         );
         this.on("destroy", () => {

--- a/stores/firestore/entityMetadata.ts
+++ b/stores/firestore/entityMetadata.ts
@@ -79,6 +79,7 @@ export class EntityMetaData extends EventEmitter {
                         `You don't have permission to access ${this.reference?.path}`
                     );
                 }
+                throw err;
             }
         );
         this.on("destroy", () => {

--- a/stores/firestore/query.ts
+++ b/stores/firestore/query.ts
@@ -143,21 +143,31 @@ export class Query extends EventEmitter {
 
             this.on(
                 "destroy",
-                onSnapshot(q, (snapshot) => {
-                    const onlyModified = snapshot.docChanges().every((change) => {
-                        return change.type === "modified";
-                    });
-                    if (onlyModified) return update();
+                onSnapshot(
+                    q,
+                    (snapshot) => {
+                        const onlyModified = snapshot.docChanges().every((change) => {
+                            return change.type === "modified";
+                        });
+                        if (onlyModified) return update();
 
-                    void update(
-                        snapshot.docs.map((doc) => {
-                            const model = this.transform(doc);
+                        void update(
+                            snapshot.docs.map((doc) => {
+                                const model = this.transform(doc);
 
-                            return model;
-                        }),
-                        snapshot.docs
-                    );
-                })
+                                return model;
+                            }),
+                            snapshot.docs
+                        );
+                    },
+                    (err) => {
+                        if (err instanceof Error && err.code === "permission-denied") {
+                            throw new Error(
+                                `You don't have permission to access ${this.reference?.path}`
+                            );
+                        }
+                    }
+                )
             );
         });
     }

--- a/stores/firestore/query.ts
+++ b/stores/firestore/query.ts
@@ -166,6 +166,7 @@ export class Query extends EventEmitter {
                                 `You don't have permission to access ${this.reference?.path}`
                             );
                         }
+                        throw err;
                     }
                 )
             );


### PR DESCRIPTION
Cette pull request permet de détailler les erreurs de permissions sur firestore en production.

Tout de suite les erreurs ressemblent à cela.
```
FirebaseError: [code=permission-denied]: Missing or insufficient permissions.
    at <anonymous> (FirebaseError: Missing or insufficient permissions.::) 
```