### PR TITLE
chore: refactoring some components

### DIFF
--- a/components/base/accordion/VCollapse.vue
+++ b/components/base/accordion/VCollapse.vue
@@ -27,7 +27,7 @@ watch(
     () => props.isOpen,
     () => {
         isOpen.value = props.isOpen;
-    }
+    },
 );
 </script>
 
@@ -58,7 +58,6 @@ watch(
 
 .collapse {
     padding: 0;
-    margin-bottom: 1.5rem;
     max-width: 100%;
 
     &[open] {

--- a/components/base/icon/VIcon.vue
+++ b/components/base/icon/VIcon.vue
@@ -36,7 +36,7 @@ const styles = getIconStyles();
 
 <style lang="scss">
 .icon {
-    font-size: v-bind(size);
+    font-size: v-bind(size) !important;
     height: v-bind(size) !important;
     width: v-bind(size) !important;
     display: flex;

--- a/components/base/tabs/VTabs.vue
+++ b/components/base/tabs/VTabs.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import type { Colors } from "../../../stores/color";
-import { useColor } from "../../../stores/color";
 import { computed } from "vue";
+import type { Colors } from "../../../stores/color";
+import { useColor, useInvertedColor } from "../../../stores/color";
 
 export type VTabsType = "boxed" | "toggle" | "rounded";
 export type VTabsAlign = "centered" | "right";
@@ -37,6 +37,7 @@ const props = withDefaults(defineProps<VTabsProps>(), {
 });
 
 const color = useColor(computed(() => props.color));
+const textColor = useInvertedColor(computed(() => props.color));
 
 const activeValue = computed({
     get() {
@@ -175,11 +176,7 @@ function toggle(value: string) {
                 a {
                     background: v-bind(color) !important;
                     border-color: v-bind(color) !important;
-
-                    &:hover,
-                    &:focus {
-                        color: var(--white);
-                    }
+                    color: v-bind(textColor) !important;
                 }
             }
 
@@ -202,7 +199,6 @@ function toggle(value: string) {
                 &:hover,
                 &:focus {
                     border-bottom-color: v-bind(color) !important;
-                    color: v-bind(color) !important;
                 }
             }
         }
@@ -243,6 +239,10 @@ function toggle(value: string) {
                 margin-left: 5px;
             }
         }
+    }
+
+    > ul {
+        margin: 0;
     }
 }
 

--- a/scss/components/_content.scss
+++ b/scss/components/_content.scss
@@ -12,7 +12,7 @@
 .content {
     ol,
     ul {
-        color: var(--dark-text);
+        //color: var(--dark-text);
         font-family: $family-sans-serif;
 
         &.is-light {

--- a/scss/css-variables/_colors.scss
+++ b/scss/css-variables/_colors.scss
@@ -8,25 +8,31 @@ $varColors: (
     "primary": $primary,
     "primary-dark": $primary-dark,
     "primary-light": $primary-light,
+    "primary-invert": $primary-invert,
 
     "info": $info,
     "info-dark": $info-dark,
     "info-light": $info-light,
+    "info-invert": $info-invert,
 
     "success": $success,
     "success-dark": $success-dark,
     "success-light": $success-light,
+    "success-invert": $success-invert,
 
     "warning": $warning,
     "warning-dark": $warning-dark,
     "warning-light": $warning-light,
+    "warning-invert": $warning-invert,
 
     "danger": $danger,
     "danger-dark": $danger-dark,
     "danger-light": $danger-light,
+    "danger-invert": $danger-invert,
 
     "black-bis": $black-bis,
     "black-ter": $black-ter,
+    "black-invert": $black,
 
     "grey-darker": $grey-darker,
     "grey-dark": $grey-dark,
@@ -38,16 +44,25 @@ $varColors: (
     "white-bis": $white-bis,
 
     "gold": $gold,
+
     "silver": $silver,
+
     "bronze": $bronze,
 
     "orange": $orange,
+
     "yellow": $yellow,
+
     "green": $green,
+
     "turquoise": $turquoise,
+
     "cyan": $cyan,
+
     "blue": $blue,
+
     "purple": $purple,
+
     "red": $red,
 );
 

--- a/stores/color.ts
+++ b/stores/color.ts
@@ -1,6 +1,5 @@
-import { useCssVar, toValue } from "@vueuse/core";
+import { toValue, useCssVar } from "@vueuse/core";
 import type { Ref } from "vue";
-import { computed } from "vue";
 
 export type Colors =
     | "primary"
@@ -40,10 +39,13 @@ export type Colors =
     | "red";
 
 export function useColor(color: Ref<Colors> | Colors) {
-    return useCssVar(
-        computed(() => {
-            return `--${toValue(color)}`;
-        }),
-        document.body
-    );
+    return useCssVar(() => {
+        return `--${toValue(color)}`;
+    }, document.body);
+}
+
+export function useInvertedColor(color: Ref<Colors> | Colors) {
+    return useCssVar(() => {
+        return `--${toValue(color)}-invert`;
+    }, document.body);
 }

--- a/stores/translate.ts
+++ b/stores/translate.ts
@@ -72,7 +72,7 @@ export function translate(options: any, component: any, values?: any) {
                 console.error(e);
             }
         }
-        while ((parentComponent = parentComponent.parent) !== undefined) {
+        while ((parentComponent = parentComponent.parent) !== null) {
             const currentIndex: number = index;
             if (parentComponent.translationNamespace !== undefined) {
                 translationNamespaces[currentIndex] =


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
This PR includes the following enhancements:
- Updated styles in the VCollapse component:
  - Removed the `margin-bottom` property from the `.collapse` class.
  - Added a `transition-all` test to the `.collapse` class.
- Refactored event listeners in the VAction component:
  - Added type annotations for `ComponentPublicInstance` and `RouteLocation`.
  - Added the `onUnmounted` lifecycle hook.
  - Refactored the event listener code to use `buttonElement` and `routerElement` refs.
  - Extracted the `vibrate` function.
- Updated styles in the VIcon component:
  - Added `!important` to the `font-size` property in the `.icon` class.
- Updated styles in the VTabs component:
  - Added the `useInvertedColor` function import.
  - Added the `textColor` constant.
  - Updated styles in the `.is-active` class to use the `textColor` variable.
- Commented out the `color` property in the `.content` class in the `_content.scss` file.
- Added invert color variables (`primary-invert`, `info-invert`, `success-invert`, `warning-invert`, `danger-invert`, and `black-invert`) in the `_colors.scss` file.
- Removed an unused import in the `color.ts` file.
- Refactored the `translate` function in the `translate.ts` file to use `resolveUnref` and `syncRef`.
- Refactored the `setTranslateNamespace` function in the `translate.ts` file to accept an optional `instance` parameter and added missing type annotations.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>VCollapse.vue</strong><dd><code>Updated styles in VCollapse component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/base/accordion/VCollapse.vue
- Removed the `margin-bottom` property from the `.collapse` class.
- Added a `transition-all` test to the `.collapse` class.
    </details>
  </td>
  <td><a href="https://github.com/add-eus/library/pull/131/files#diff-3d4c7eff4fac209447428e91634bc104b741f93af259ed3ac82612b47de8935f">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>VAction.vue</strong><dd><code>Refactored event listeners in VAction component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/base/button/VAction.vue
- Added type annotations for `ComponentPublicInstance` and <br>  `RouteLocation`.
- Added `onUnmounted` lifecycle hook.
- Refactored event listener code to use `buttonElement` and <br>  `routerElement` refs.
- Extracted the `vibrate` function.
    </details>
  </td>
  <td><a href="https://github.com/add-eus/library/pull/131/files#diff-f831ff3f9b41b599fa8c3d43b2aad0b975709e6d004c566095e92da28995d12f">+40/-11</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>VIcon.vue</strong><dd><code>Updated styles in VIcon component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/base/icon/VIcon.vue
- Added `!important` to the `font-size` property in the `.icon` class.
    </details>
  </td>
  <td><a href="https://github.com/add-eus/library/pull/131/files#diff-d71db23088dc6343c9e8e9ec132570ae04900463a891905281eea79c9e81c68f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>VTabs.vue</strong><dd><code>Updated styles in VTabs component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/base/tabs/VTabs.vue
- Added `useInvertedColor` function import.
- Added `textColor` constant.
- Updated styles in the `.is-active` class to use `textColor` variable.
    </details>
  </td>
  <td><a href="https://github.com/add-eus/library/pull/131/files#diff-1ef57626ba1a167bae324874f2f4de9c8334e1a5e4a0c45870a56be44b44958b">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>_content.scss</strong><dd><code>Commented out color property in _content.scss</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scss/components/_content.scss
- Commented out the `color` property in the `.content` class.
    </details>
  </td>
  <td><a href="https://github.com/add-eus/library/pull/131/files#diff-5be3deb81b8dc7537d39220da9f320f30e1574b5b32184511500891d5502af28">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>_colors.scss</strong><dd><code>Added invert color variables in _colors.scss</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scss/css-variables/_colors.scss
- Added `primary-invert`, `info-invert`, `success-invert`, `<br>  ``warning-invert`, `<br>  ``danger-invert`, `<br>  `and `<br>  ``black-invert` <br>  color variables.
    </details>
  </td>
  <td><a href="https://github.com/add-eus/library/pull/131/files#diff-f17befa3d68647fc15510c224486edf4001baf5d16bc7b6a6b42fac93192e091">+15/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>color.ts</strong><dd><code>Removed unused import in color.ts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

stores/color.ts
- Removed unused import.
    </details>
  </td>
  <td><a href="https://github.com/add-eus/library/pull/131/files#diff-b4e2b27afa813eb26e11f9431ec9f51d093089fc7121a698910275b924dd29a3">+10/-8</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>translate.ts</strong><dd><code>Refactored translate.ts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

stores/translate.ts
- Added missing type annotations.
- Refactored the `translate` function to use `resolveUnref` and <br>  `syncRef`.
- Refactored the `setTranslateNamespace` function to accept an optional <br>  `instance` parameter.
- Added missing type annotations for the `instance` parameter in <br>  `setTranslateNamespace` function.
    </details>
  </td>
  <td><a href="https://github.com/add-eus/library/pull/131/files#diff-8486e209c999be95c012ae6b3e56aff47b86fdf3ef6cf29d5c9b17e457765f2c">+18/-17</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
