### PR TITLE
feat: add croping default size

### DIFF
--- a/components/base/VCrop.vue
+++ b/components/base/VCrop.vue
@@ -31,6 +31,12 @@ defineExpose({ getResult });
             :min-width="props.options?.minWidth"
             :max-height="props.options?.maxHeight"
             :max-width="props.options?.maxWidth"
-            :size-restrictions-algorithm="(size: any) => size" />
+            :size-restrictions-algorithm="(size: any) => size"
+            :default-size="
+                ({ imageSize, visibleArea }) => ({
+                    width: (visibleArea || imageSize).width,
+                    height: (visibleArea || imageSize).height,
+                })
+            " />
     </div>
 </template>


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Added a `default-size` prop to the `VCrop` component in `components/base/VCrop.vue`.
- The `default-size` prop is a function that calculates the default size of the crop area based on the `imageSize` and `visibleArea` properties.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>VCrop.vue</strong><dd><code>Add `default-size` prop to `VCrop` component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/base/VCrop.vue
<li>Added a <code>default-size</code> prop to the <code>VCrop</code> component.<br> <li> The <code>default-size</code> prop is a function that calculates the default size <br>of the crop area based on the <code>imageSize</code> and <code>visibleArea</code> properties.


</details>
    

  </td>
  <td><a href="https:/add-eus/library/pull/141/files#diff-6648eee69107bf773636544e3d5414cffdf3251ab58f928bf4a282769b9ab4ba">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

