### PR TITLE
feat: set file on error when unauthorized fetch

### DIFF
--- a/components/base/form/VFile.vue
+++ b/components/base/form/VFile.vue
@@ -106,7 +106,7 @@ const uploadedImages = computed(() => {
     });
 });
 
-async function load(url, load) {
+async function load(url, load, error) {
     if (url.constructor === File) return load(url);
     try {
         const blob = await storage.fetch(url);
@@ -114,6 +114,7 @@ async function load(url, load) {
     } catch (err) {
         // eslint-disable-next-line no-console
         console.error(err);
+        if (typeof err === "object" && err.code === "storage/unauthorized") error();
     }
 }
 


### PR DESCRIPTION
ça a pour conséquence de supprimer le fichier en question du model passé à VFile.
Je met ça pour les fichiers qu'on a déplacer de /posts/file.png à /post/{profileId}/file.png
On a plus accès au premier path car on peut pas faire de sécu en fonction du profile.

J'ai filtré par type d'erreur au cas où quelqu'un qui ne récupére pas le fichier pour une raison inconnu (problème de connexion indépendant de nous par exemple) ne vois pas son fichier supprimé.