### PR TITLE
fix: fix onUpdate call

### DIFF
--- a/stores/firestore/query.ts
+++ b/stores/firestore/query.ts
@@ -37,7 +37,7 @@ class Queue {
         callback: (
             startAfter: undefined | any,
             update: (list?: any, docs?: any) => void,
-        ) => any,
+        ) => void,
     ): Promise<any> {
         const chunkIndex = this.chunk.length;
         const waitPrevious = Promise.all(this.queue);
@@ -83,7 +83,11 @@ class Queue {
 
                     resolve(list);
                 };
-                callback(previousItem, onUpdate).then(undefined, reject);
+                try {
+                    callback(previousItem, onUpdate);
+                } catch (err) {
+                    reject(err);
+                }
             };
         });
 


### PR DESCRIPTION
## **Type**
bug_fix


___

## **Description**
- Updated the callback return type in the `add` method to enforce a `void` return type, enhancing type safety.
- Introduced error handling for the callback execution within the `add` method to gracefully handle and reject errors, improving the robustness of the Firestore query functionality.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>query.ts</strong><dd><code>Improved Error Handling and Callback Signature in Firestore Query</code></dd></summary>
<hr>

stores/firestore/query.ts
<li>Changed the callback return type from <code>any</code> to <code>void</code> in the <code>add</code> method <br>signature.<br> <li> Wrapped the callback invocation in a <code>try-catch</code> block to handle <br>potential errors.<br>


</details>
    

  </td>
  <td><a href="https://github.com/add-eus/library/pull/150/files#diff-9adb2fe930338f01ecb373abe43a8dfeef484ce64207fee5689ba9f9cfcf1377">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

