### PR TITLE
fix: fix blacklisted property rules

### DIFF
--- a/stores/firestore/security/rules.ts
+++ b/stores/firestore/security/rules.ts
@@ -156,8 +156,8 @@ const createPropertiesRules = (
         .map((property) => {
             const rule = modelSecurity?.properties?.[property][operation];
             if (rule === "false")
-                return `request.resource.data['role'] == resource.data['${property}']`;
-            return `(request.resource.data['role'] == resource.data['${property}'] || ${modelSecurity?.properties?.[property][operation]})`;
+                return `request.resource.data['${property}'] == resource.data['${property}']`;
+            return `(request.resource.data['${property}'] == resource.data['${property}'] || ${modelSecurity?.properties?.[property][operation]})`;
         })
         .join(" && ")})`;
 };

--- a/stores/firestore/security/rules.ts
+++ b/stores/firestore/security/rules.ts
@@ -156,8 +156,8 @@ const createPropertiesRules = (
         .map((property) => {
             const rule = modelSecurity?.properties?.[property][operation];
             if (rule === "false")
-                return `!request.resource.data.keys().hasAny(["${property}"])`;
-            return `(!request.resource.data.keys().hasAny(["${property}"]) || ${modelSecurity?.properties?.[property][operation]})`;
+                return `request.resource.data['role'] == resource.data['${property}']`;
+            return `(request.resource.data['role'] == resource.data['${property}'] || ${modelSecurity?.properties?.[property][operation]})`;
         })
         .join(" && ")})`;
 };


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed the condition for blacklisted property rules in Firestore security rules.
- Updated the logic to ensure `request.resource.data['role']` matches `resource.data['property']`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rules.ts</strong><dd><code>Fix blacklisted property rules logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

stores/firestore/security/rules.ts
<li>Fixed the condition for blacklisted property rules.<br> <li> Updated the logic to check if <code>request.resource.data['role']</code> matches <br><code>resource.data['property']</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/add-eus/library/pull/152/files#diff-2b43254787497e5f8e3347c6323f60e42a438ef57653aadb50f0a98c809cb96c">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

