### PR TITLE
feat: add max timeout to functions

### DIFF
--- a/stores/function.ts
+++ b/stores/function.ts
@@ -21,11 +21,12 @@ export async function httpsOpen(path: string, args: { [name: string]: string | n
 export default new Proxy(
     {},
     {
-        get(object: { [key: string]: Function }, name: string) {
+        get(object: { [key: string]: ((...args) => any) | undefined }, name: string) {
             if (!object[name]) {
                 const callableFunction = firebaseHttpsCallable(
                     useFirebase().functions,
-                    name
+                    name,
+                    { timeout: 540_000 },
                 );
                 object[name] = async function (...args: any[]) {
                     const result = await callableFunction(...args, navigator?.language);
@@ -34,5 +35,5 @@ export default new Proxy(
             }
             return object[name];
         },
-    }
+    },
 );


### PR DESCRIPTION
### **User description**
Certaines functions peuvent durer plus de 60s (540s max), j'ai donc augmenter la limite pour correspondre au maximum.

C'est utile dans le cadre de la génération de planning où on peut attendre une réponse plus longtemps que 60s, dans l'audit on a involontairement contourné le problème en attendant que le document de l'audit soit créé par la cloud function et non la réponse de celle-ci. Mais pour la génération de planning, on est obligé d'attendre la réponse réel de la fonction.


___

### **PR Type**
Enhancement


___

### **Description**
- Added a timeout option to the `firebaseHttpsCallable` function to allow functions to run up to 540,000 milliseconds (9 minutes).
- Updated the type definition for the `get` method in the Proxy handler to accommodate the new timeout option.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>function.ts</strong><dd><code>Add max timeout to Firebase callable functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

stores/function.ts

<li>Added a timeout option to the <code>firebaseHttpsCallable</code> function.<br> <li> Set the timeout to 540,000 milliseconds (9 minutes).<br> <li> Updated the type definition for the <code>get</code> method in the Proxy handler.<br>


</details>


  </td>
  <td><a href="https://github.com/add-eus/library/pull/154/files#diff-88dfa548d08d911ea85152a7416f8ab8c3a5553b249e1303d26818de5cb6323d">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

