### PR TITLE
feat: add video preload props to ImageFirestore

### DIFF
--- a/components/base/firebase/ImageFirestore.vue
+++ b/components/base/firebase/ImageFirestore.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { useStorage } from "../../../stores/storage";
-import { computed, ref } from "vue";
 import { computedAsync } from "@vueuse/core";
+import { computed, ref } from "vue";
+import { useStorage } from "../../../stores/storage";
 
 interface FirebaseImageProps {
     path: string;
     alt: string;
+    videoPreload: "auto" | "metadata" | "none";
 }
 
 const DEFAULT_IMAGE =
@@ -31,7 +32,7 @@ const src = computedAsync(
         }
     },
     undefined,
-    evaluating
+    evaluating,
 );
 
 const mimeType = computed(() => {
@@ -51,7 +52,7 @@ const isVideo = computed(() => {
             <slot v-if="evaluating" name="loading" v-bind="$attrs">
                 <VPlaceload height="100%" width="100%"></VPlaceload>
             </slot>
-            <video v-else-if="isVideo" v-bind="$attrs">
+            <video v-else-if="isVideo" :preload="videoPreload" v-bind="$attrs">
                 <source :src="src" :type="mimeType" />
 
                 <track kind="captions" />


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added a new `videoPreload` prop to the `FirebaseImageProps` interface, allowing control over video preload behavior.
- Updated the video element in the `ImageFirestore` component to utilize the new `videoPreload` prop.
- Reorganized imports for better readability and maintainability.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ImageFirestore.vue</strong><dd><code>Add video preload property to ImageFirestore component</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/base/firebase/ImageFirestore.vue

<li>Added <code>videoPreload</code> prop to <code>FirebaseImageProps</code> interface.<br> <li> Updated video element to use <code>videoPreload</code> prop.<br> <li> Reordered imports for better organization.<br>


</details>


  </td>
  <td><a href="https://github.com/add-eus/library/pull/156/files#diff-10087eeb39afe5169322cab22ed116733986d1fa2f4de21061a9fc3c2c1e11b7">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

