### PR TITLE
feat: remove subcollection default list

### DIFF
--- a/stores/firestore/collection.ts
+++ b/stores/firestore/collection.ts
@@ -1,8 +1,5 @@
-import { watchArray } from "@vueuse/core";
 import type { MaybeRef } from "@vueuse/core";
-import type { DocumentData, DocumentReference } from "firebase/firestore";
-import { collection, deleteDoc, doc, getDoc, setDoc } from "firebase/firestore";
-import { shallowReactive } from "vue";
+import { doc, getDoc } from "firebase/firestore";
 import type { Ref } from "vue";
 import type {
     CollectionOptions as UseCollectionOption,
@@ -122,13 +119,9 @@ export function Collection<T>(options: CollectionOptions<T>) {
 }
 
 export class SubCollection<T extends Entity> {
-    private firestoreArray?: UseCollectionType<T>;
-    private currentList = shallowReactive(new Array<T>());
     private model?: typeof Entity;
     private path?: string;
     private initialized = false;
-    private stopWatch?: () => void;
-    private isFetched = false;
     private new = false;
     public blacklistedProperties: string[] = [];
 
@@ -142,47 +135,6 @@ export class SubCollection<T extends Entity> {
         this.blacklistedProperties = blacklistedProperties;
         this.initialized = true;
         this.new = path === undefined;
-    }
-
-    setOptions(options?: Omit<UseCollectionOption, "path" | "blacklistedProperties">) {
-        if (!this.initialized) throw new Error(`property subcollection not initialized`);
-        if (this.model === undefined)
-            throw new Error(`model in property ${this.path} is undefined`);
-        if (this.path === undefined)
-            throw new Error(`path in property ${this.path} is undefined`);
-
-        this.stopWatch?.();
-
-        const useCollectionOptions: UseCollectionOption = {
-            ...options,
-            path: this.path,
-            blacklistedProperties: this.blacklistedProperties,
-        };
-        this.firestoreArray = useCollection(
-            this.model,
-            useCollectionOptions,
-        ) as UseCollectionType<T>;
-
-        this.currentList.splice(0, this.currentList.length);
-
-        this.stopWatch = watchArray(
-            this.firestoreArray,
-            (value, oldValue, added: T[], removed: T[]) => {
-                added.forEach((a) => {
-                    const alreadyInArray = this.currentList.some(
-                        (entity) => entity.$getID() === a.$getID(),
-                    );
-                    if (!alreadyInArray) this.currentList.push(a);
-                });
-                removed.forEach((r) => {
-                    const index = this.currentList.findIndex(
-                        (entity) => entity.$getID() === r.$getID(),
-                    );
-                    if (index !== -1) this.currentList.splice(index, 1);
-                });
-            },
-        );
-        this.isFetched = true;
     }
 
     async exists(entity: Entity): Promise<boolean> {
@@ -199,11 +151,6 @@ export class SubCollection<T extends Entity> {
         return snap.exists();
     }
 
-    get list() {
-        if (!this.isFetched && !this.new) this.setOptions();
-        return this.currentList;
-    }
-
     get entityModel() {
         return this.model;
     }
@@ -216,41 +163,21 @@ export class SubCollection<T extends Entity> {
         return this.new;
     }
 
-    fetched() {
-        if (!this.isFetched) throw new Error(`property subcollection not initialized`);
-        if (this.firestoreArray === undefined)
-            throw new Error(`firestoreArray is undefined`);
-        return this.firestoreArray.fetched();
-    }
-
-    /**
-     * Get array modification between app datas and firestore datas
-     * @param appArray Current data in app (with new or deleted entities)
-     * @param firestoreArray Current data in firestore
-     * @returns {toDelete, toAdd} entities to delete and entities to add
-     */
-    getArrayModification() {
-        const dbEntities: Entity[] = [];
-        if (this.firestoreArray) dbEntities.push(...this.firestoreArray);
-        const appEntities = [...this.currentList];
-
-        const toDelete = dbEntities.filter(
-            (f) => !appEntities.some((a) => a.$getID() === f.$getID()),
-        );
-        const toAdd = appEntities.filter(
-            (a) => !dbEntities.some((f) => a.$getID() === f.$getID()),
-        );
-        return { toDelete, toAdd };
-    }
-
-    newDoc(): T {
+    newDoc(toClone?: T): T {
         if (!this.isInitialized)
             throw new Error(`property subcollection not initialized`);
         if (this.model === undefined) throw new Error(`model is undefined`);
-        const entity = newDoc(this.model) as T;
-        entity.$getMetadata().saveNewDocPath = this.path;
-        this.currentList.push(entity);
-        return entity;
+        if (toClone === undefined) {
+            const entity = newDoc(this.model) as T;
+            entity.$getMetadata().saveNewDocPath = this.path;
+            return entity;
+        } else {
+            if (this.path === undefined) throw new Error(`path is undefined`);
+            const entity = toClone.$clone() as T;
+            entity.$getMetadata().saveNewDocPath = this.path;
+            entity.$getMetadata().saveNewDocId = toClone.$getID();
+            return entity;
+        }
     }
 
     useDoc(id: string): T {
@@ -285,56 +212,3 @@ export class SubCollection<T extends Entity> {
         return useCount(this.path, whereOptions);
     }
 }
-
-/**
- * Add and/or remove elements from firestore
- * @param toRemove elements to remove
- * @param toAdd elements to add
- * @param path path of the collection
- */
-export const updatePropertyCollection = async (
-    toRemove: Array<Entity>,
-    toAdd: Array<Entity>,
-    path: string,
-    blacklistedProperties: string[] = [],
-) => {
-    const firestore = useFirestore();
-
-    const collectionRef = collection(firestore, path);
-    const removePromises = toRemove.map(async (entity) => {
-        const id = entity.$getMetadata().reference?.id;
-        if (id === undefined) throw new Error("id is undefined");
-        const docRef = doc(collectionRef, id);
-        await deleteDoc(docRef);
-    });
-    const addPromises = toAdd.map(async (entity) => {
-        let id = entity.$getMetadata().reference?.id;
-
-        // entity is already in collection
-        if (entity.$getMetadata().reference?.path === `${collectionRef.path}/${id}`) {
-            return;
-        }
-
-        let docRef: DocumentReference<DocumentData> | undefined;
-        if (id === undefined) {
-            // entity is new, save it before add to collection
-            await entity.$save();
-            const reference = entity.$getMetadata().reference;
-            if (reference === null) throw new Error("reference is null");
-            id = reference.id;
-            docRef = reference;
-        } else {
-            docRef = doc(collectionRef, id);
-            await setDoc(docRef, entity.$getPlain(), { merge: true });
-        }
-
-        // save sub collections of added entity recursively
-        const constructor = entity.constructor as typeof Entity;
-        const model = new constructor();
-        const metadata = model.$getMetadata();
-        metadata.setReference(docRef);
-        metadata.blacklistedProperties = blacklistedProperties;
-        await metadata.savePropertyCollections(entity);
-    });
-    await Promise.all([...removePromises, ...addPromises]);
-};

--- a/stores/firestore/entity.ts
+++ b/stores/firestore/entity.ts
@@ -10,8 +10,8 @@ import {
 } from "firebase/firestore";
 import { isReactive, markRaw, shallowReactive } from "vue";
 import { lowerCaseFirst } from "../../utils/string";
-import { EntityMetaData } from "./entityMetadata";
 import { useFirestore } from "../firebase";
+import { EntityMetaData } from "./entityMetadata";
 
 export function onInitialize(
     target: any,
@@ -139,7 +139,6 @@ export class Entity extends EntityBase {
     static collectionName: string;
 
     $setAndParseFromReference(querySnapshot: DocumentReference | DocumentSnapshot) {
-        
         const metadata = this.$getMetadata();
         if (querySnapshot instanceof DocumentReference) {
             metadata.setReference(querySnapshot);
@@ -191,12 +190,15 @@ export class Entity extends EntityBase {
         try {
             if (isNew) {
                 const firestore = useFirestore();
-                const docRef = doc(
-                    collection(
-                        firestore,
-                        $metadata.saveNewDocPath ?? constructor.collectionName,
-                    ),
+                console.log($metadata.saveNewDocId);
+                const docCollection = collection(
+                    firestore,
+                    $metadata.saveNewDocPath ?? constructor.collectionName,
                 );
+                const docRef =
+                    $metadata.saveNewDocId === undefined
+                        ? doc(docCollection)
+                        : doc(docCollection, $metadata.saveNewDocId);
 
                 $metadata.setReference(docRef);
 
@@ -224,9 +226,6 @@ export class Entity extends EntityBase {
                 return this.$save();
             throw err;
         }
-
-        // save subcollections
-        await $metadata.savePropertyCollections();
 
         this.$getMetadata().emit("saved", this);
     }

--- a/stores/firestore/entity.ts
+++ b/stores/firestore/entity.ts
@@ -190,7 +190,6 @@ export class Entity extends EntityBase {
         try {
             if (isNew) {
                 const firestore = useFirestore();
-                console.log($metadata.saveNewDocId);
                 const docCollection = collection(
                     firestore,
                     $metadata.saveNewDocPath ?? constructor.collectionName,

--- a/stores/firestore/entityMetadata.ts
+++ b/stores/firestore/entityMetadata.ts
@@ -1,8 +1,8 @@
-import type { Entity } from "./entity";
 import type { DocumentReference, DocumentSnapshot } from "firebase/firestore";
 import { getDoc, onSnapshot } from "firebase/firestore";
+import { SubCollection, entitiesInfos } from "./collection";
+import type { Entity } from "./entity";
 import EventEmitter from "./event";
-import { SubCollection, entitiesInfos, updatePropertyCollection } from "./collection";
 
 export interface CollectionProperties {
     [key: string]: { namespace: string; blacklistedProperties: string[] };
@@ -23,6 +23,7 @@ export class EntityMetaData extends EventEmitter {
     blacklistedProperties: string[] = [];
     collectionProperties: CollectionProperties = {};
     saveNewDocPath?: string;
+    saveNewDocId?: string;
 
     constructor(entity: any) {
         super();
@@ -40,8 +41,6 @@ export class EntityMetaData extends EventEmitter {
             this.isFullfilling = getDoc(this.reference);
 
             const querySnapshot = await this.isFullfilling;
-
-            
 
             this.entity.$setAndParseFromReference(querySnapshot);
         }
@@ -87,11 +86,11 @@ export class EntityMetaData extends EventEmitter {
             (err) => {
                 if (err instanceof Error && err.code === "permission-denied") {
                     throw new Error(
-                        `You don't have permission to access ${this.reference?.path}`
+                        `You don't have permission to access ${this.reference?.path}`,
                     );
                 }
                 throw err;
-            }
+            },
         );
     }
 
@@ -127,66 +126,8 @@ export class EntityMetaData extends EventEmitter {
                 subCollection.init(
                     info.model,
                     isNew ? undefined : `${this.reference!.path}/${propertyKey}`,
-                    blacklistedProperties
+                    blacklistedProperties,
                 );
             });
-    }
-
-    async savePropertyCollections(copyFrom?: Entity) {
-        const savePropertyCollectionPromises = Object.keys(this.collectionProperties).map(
-            async (propertyKey) => {
-                await this.savePropertyCollection(propertyKey, copyFrom);
-            }
-        );
-        await Promise.all(savePropertyCollectionPromises);
-    }
-
-    async savePropertyCollection(propertyKey: string, copyFrom?: Entity) {
-        if (this.reference === null) throw new Error("reference in metadata is null");
-
-        const constructor = this.entity.constructor as typeof Entity;
-        const info = entitiesInfos.get(constructor.collectionName);
-        if (info === undefined)
-            throw new Error(`${constructor.collectionName} info is undefined`);
-
-        const propertySubCollection = (this.entity as any)[
-            propertyKey
-        ] as SubCollection<Entity>;
-        if (propertySubCollection.isNew) {
-            propertySubCollection.init(
-                propertySubCollection.entityModel!,
-                `${this.reference.path}/${propertyKey}`,
-                propertySubCollection.blacklistedProperties
-            );
-        }
-        const copiedSubCollection =
-            copyFrom === undefined
-                ? undefined
-                : ((copyFrom as any)[propertyKey] as SubCollection<Entity>);
-        // get blacklisted properties of entity collection
-        const parentBlacklistedProperties: string[] = [];
-        entitiesInfos.forEach((info) => {
-            info.subPaths.forEach((subPath) => {
-                if (subPath.path === this.reference?.parent.id)
-                    parentBlacklistedProperties.push(...subPath.blacklistedProperties);
-            });
-        });
-        if (parentBlacklistedProperties.includes(propertyKey)) return;
-
-        // elements changed in array, if copyFrom is defined, it's a new entity, all elements are added from copyFrom
-        const { toDelete, toAdd } =
-            copiedSubCollection !== undefined
-                ? {
-                      toDelete: [],
-                      toAdd: [...copiedSubCollection.list],
-                  }
-                : propertySubCollection.getArrayModification();
-
-        await updatePropertyCollection(
-            toDelete,
-            toAdd,
-            `${this.reference.path}/${propertyKey}`,
-            parentBlacklistedProperties
-        );
     }
 }

--- a/stores/firestore/entityMetadata.ts
+++ b/stores/firestore/entityMetadata.ts
@@ -17,7 +17,7 @@ export class EntityMetaData extends EventEmitter {
     previousOrigin: any = {};
     properties: { [key: string]: any } = {};
     entity: Entity;
-    unsuscribeSnapshot: Function | null = null;
+    unsuscribeSnapshot: (() => void) | null = null;
     disableWatch: boolean = false;
 
     blacklistedProperties: string[] = [];


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Removed the default list handling in `SubCollection`.

- Simplified `SubCollection` by removing unused methods and properties.

- Enhanced `Entity` to support cloning with specific IDs.

- Refactored `EntityMetaData` to remove redundant collection saving logic.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>collection.ts</strong><dd><code>Simplified SubCollection by removing default list handling</code></dd></summary>
<hr>

stores/firestore/collection.ts

<li>Removed default list handling and related methods in <code>SubCollection</code>.<br> <li> Simplified <code>newDoc</code> method to support cloning with specific IDs.<br> <li> Removed unused properties and methods like <code>setOptions</code>, <code>fetched</code>, and <br><code>getArrayModification</code>.<br> <li> Deleted <code>updatePropertyCollection</code> utility function.


</details>


  </td>
  <td><a href="https://github.com/add-eus/library/pull/161/files#diff-f62b4907360562e7ce9e2fb23f5f1b74309851ea68ee0dda88fdbc56aba9628b">+13/-139</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>entity.ts</strong><dd><code>Enhanced Entity for cloning and Firestore integration</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

stores/firestore/entity.ts

<li>Enhanced <code>$save</code> method to support cloning entities with specific IDs.<br> <li> Adjusted logic for creating document references in Firestore.<br> <li> Removed redundant subcollection saving logic.


</details>


  </td>
  <td><a href="https://github.com/add-eus/library/pull/161/files#diff-5b81caaf1f137ca11862087a4c21d7c08bad8c46374c4e4af8063d3e66c3f7fa">+9/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>entityMetadata.ts</strong><dd><code>Refactored EntityMetaData to streamline subcollection handling</code></dd></summary>
<hr>

stores/firestore/entityMetadata.ts

<li>Removed redundant methods for saving property collections.<br> <li> Added support for saving new document IDs in metadata.<br> <li> Simplified subcollection initialization logic.


</details>


  </td>
  <td><a href="https://github.com/add-eus/library/pull/161/files#diff-c40b97c8d9376c9f6c7acd7f192a7de5ae2d0ad7af457a137087054ea20c7912">+6/-65</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>