### PR TITLE
Fix new doc sub collections

### DIFF
--- a/stores/firestore/collection.ts
+++ b/stores/firestore/collection.ts
@@ -167,12 +167,12 @@ export class SubCollection<T extends Entity> {
         if (!this.isInitialized)
             throw new Error(`property subcollection not initialized`);
         if (this.model === undefined) throw new Error(`model is undefined`);
+        if (this.path === undefined) throw new Error(`path is undefined`);
         if (toClone === undefined) {
             const entity = newDoc(this.model) as T;
             entity.$getMetadata().saveNewDocPath = this.path;
             return entity;
         } else {
-            if (this.path === undefined) throw new Error(`path is undefined`);
             const entity = toClone.$clone() as T;
             entity.$getMetadata().saveNewDocPath = this.path;
             entity.$getMetadata().saveNewDocId = toClone.$getID();

--- a/stores/firestore/entity.ts
+++ b/stores/firestore/entity.ts
@@ -204,6 +204,7 @@ export class Entity extends EntityBase {
                 this.$getMetadata().emit("beforeCreated", raw);
                 await setDoc(docRef, raw);
                 this.$getMetadata().emit("created", this);
+                this.$getMetadata().initSubCollections();
             } else if (Object.keys(raw).length > 0 && $metadata.reference !== null) {
                 this.$getMetadata().emit("beforeUpdated", raw);
                 await updateDoc($metadata.reference, raw);

--- a/stores/firestore/index.ts
+++ b/stores/firestore/index.ts
@@ -142,8 +142,8 @@ export function useCountQuery(
 export function useModelListQuery<T extends typeof Entity>(
     collectionModel: T,
     firestoreQuery: MaybeRef<FirestoreQuery<DocumentData>>,
-    startIndex: MaybeRef<number>,
-    endIndex: MaybeRef<number>,
+    startIndex?: MaybeRef<number>,
+    endIndex?: MaybeRef<number>,
 ): Collection<InstanceType<T>> {
     const onDestroy: (() => void)[] = [];
     getCurrentScope()


### PR DESCRIPTION
### **PR Type**
- Bug fix



___

### **Description**
- Added undefined path check in newDoc method.

- Initialized subcollections after document creation.

- Made query indices optional in useModelListQuery.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>collection.ts</strong><dd><code>Enforce path validation in newDoc.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

stores/firestore/collection.ts

<li>Inserted check for undefined <code>this.path</code> before document creation.<br> <li> Rearranged path validation logic in newDoc.


</details>


  </td>
  <td><a href="https://github.com/add-eus/library/pull/162/files#diff-f62b4907360562e7ce9e2fb23f5f1b74309851ea68ee0dda88fdbc56aba9628b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>entity.ts</strong><dd><code>Initialize subcollections post creation.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

stores/firestore/entity.ts

<li>Added call to <code>initSubCollections</code> after creating document.<br> <li> Ensured subcollections are properly initialized.


</details>


  </td>
  <td><a href="https://github.com/add-eus/library/pull/162/files#diff-5b81caaf1f137ca11862087a4c21d7c08bad8c46374c4e4af8063d3e66c3f7fa">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Optional query indices in list query.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

stores/firestore/index.ts

<li>Made <code>startIndex</code> and <code>endIndex</code> parameters optional.<br> <li> Updated function signature in useModelListQuery.


</details>


  </td>
  <td><a href="https://github.com/add-eus/library/pull/162/files#diff-6dfd9c1e9897d67fe5ed78b27329ba9fe82e55f289f264d77f362365811a5795">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>