### PR TITLE
fix: fix storage upload in VFile

### DIFF
--- a/components/base/form/VFile.vue
+++ b/components/base/form/VFile.vue
@@ -265,8 +265,8 @@ async function process(fieldName, file, metadata, loadFile, error) {
                 isAaspectRatioWrong.value = true;
                 return;
             }
-            const path = await storage.upload(file, props.storagePath);
-            loadFile(path);
+            const ref = await storage.upload(file, props.storagePath);
+            loadFile(ref.fullPath);
             emit("newFile", { fileType: file.type });
             skipNextFile = false;
         } else if (blob === undefined) {


### PR DESCRIPTION
### **PR Type**
Bug fix



___

### **Description**
- Rename variable from `path` to `ref`

- Use `ref.fullPath` instead of direct upload result

- Maintain file upload trigger with new file event


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>VFile.vue</strong><dd><code>Update file upload reference for full path usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/base/form/VFile.vue

<li>Updated variable assignment from <code>path</code> to <code>ref</code><br> <li> Replaced <code>loadFile(path)</code> with <code>loadFile(ref.fullPath)</code><br> <li> Preserved error handling and event emission logic


</details>


  </td>
  <td><a href="https://github.com/add-eus/library/pull/165/files#diff-b2658c7f1fddb019e99eb1d6e5b103980325cb7987b294222f66d5b1360972e0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>